### PR TITLE
feat: Add MCP response content type support for Anthropic provider

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:docs.anthropic.com)",
+      "Bash(composer install:*)",
+      "Bash(php:*)",
+      "Bash(rm:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git push:*)",
+      "Bash(./vendor/bin/pest)",
+      "Bash(find:*)",
+      "Bash(./vendor/bin/pest:*)"
+    ],
+    "deny": []
+  }
+}

--- a/docs/advanced/provider-interoperability.md
+++ b/docs/advanced/provider-interoperability.md
@@ -62,6 +62,7 @@ class AnthropicConfigurator
     {
         return $request
             ->withMaxTokens(4000)
+            ->withMCPServer('filesystem', 'https://mcp-server.com')
             ->withProviderOptions([
                 'cacheType' => 'ephemeral',
                 'citations' => true,
@@ -77,6 +78,25 @@ $response = Prism::text()
 ```
 
 This approach can be especially helpful when you have complex or reusable provider configurations.
+
+### Provider-Specific Features
+
+Some providers offer unique features that others don't support. For example, Anthropic's MCP Connector allows you to connect to external MCP servers for additional tools and resources:
+
+```php
+$response = Prism::text()
+    ->using(Provider::OpenAI, 'gpt-4o')
+    ->withPrompt('Analyze the database and create a report')
+    ->whenProvider(
+        Provider::Anthropic,
+        fn ($request) => $request
+            ->withMCPServer('database', 'https://db-server.com', 'auth-token')
+            ->withMCPServer('filesystem', 'https://fs-server.com')
+    )
+    ->asText();
+```
+
+When using OpenAI, the MCP servers are simply ignored, but when using Anthropic, they provide additional capabilities.
 
 > [!TIP]
 > The `whenProvider` method works with all request types in Prism including text, structured output, and embeddings requests.

--- a/docs/core-concepts/tools-function-calling.md
+++ b/docs/core-concepts/tools-function-calling.md
@@ -280,6 +280,26 @@ $prism = Prism::text()
 > [!WARNING]
 > Tool choice support varies by provider. Check your provider's documentation for specific capabilities.
 
+## MCP Connector (Anthropic)
+
+For Anthropic users, Prism supports the Model Context Protocol (MCP) Connector, which allows you to connect to remote MCP servers that provide tools and resources. This gives you access to external tools without having to implement them directly in your application.
+
+```php
+use Prism\Prism\Prism;
+
+$response = Prism::text()
+    ->using('anthropic', 'claude-3-sonnet')
+    ->withMCPServer('filesystem', 'https://filesystem-server.com')
+    ->withMCPServer('database', 'https://database-server.com')
+    ->withPrompt('List files and query the user database')
+    ->generate();
+```
+
+MCP Connector automatically discovers and makes available tools from connected MCP servers, extending your AI's capabilities beyond locally defined tools.
+
+> [!TIP]
+> Learn more about MCP Connector setup and configuration in the [Anthropic provider documentation](/providers/anthropic#mcp-connector).
+
 ## Response Handling with Tools
 
 When your AI uses tools, you can inspect the results and see how it arrived at its answer:

--- a/src/Concerns/HasMCPServers.php
+++ b/src/Concerns/HasMCPServers.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\Concerns;
+
+use Prism\Prism\ValueObjects\MCPServer;
+
+trait HasMCPServers
+{
+    /** @var array<MCPServer> */
+    protected array $mcpServers = [];
+
+    public function withMCPServer(
+        string $name,
+        string $url,
+        ?string $authorizationToken = null,
+        array $toolConfiguration = []
+    ): self {
+        $this->mcpServers[] = new MCPServer(
+            name: $name,
+            url: $url,
+            authorizationToken: $authorizationToken,
+            toolConfiguration: $toolConfiguration
+        );
+
+        return $this;
+    }
+
+    public function withMCPServers(array $servers): self
+    {
+        foreach ($servers as $server) {
+            if ($server instanceof MCPServer) {
+                $this->mcpServers[] = $server;
+            } elseif (is_array($server)) {
+                $this->withMCPServer(
+                    name: $server['name'],
+                    url: $server['url'],
+                    authorizationToken: $server['authorization_token'] ?? null,
+                    toolConfiguration: $server['tool_configuration'] ?? []
+                );
+            }
+        }
+
+        return $this;
+    }
+
+    public function getMCPServers(): array
+    {
+        return $this->mcpServers;
+    }
+
+    public function hasMCPServers(): bool
+    {
+        return ! empty($this->mcpServers);
+    }
+}

--- a/src/Providers/Anthropic/Anthropic.php
+++ b/src/Providers/Anthropic/Anthropic.php
@@ -8,6 +8,7 @@ use Generator;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
 use Prism\Prism\Contracts\Provider;
+use Prism\Prism\Contracts\PrismRequest;
 use Prism\Prism\Embeddings\Request as EmbeddingRequest;
 use Prism\Prism\Embeddings\Response as EmbeddingResponse;
 use Prism\Prism\Providers\Anthropic\Handlers\Stream;
@@ -32,7 +33,8 @@ readonly class Anthropic implements Provider
         $handler = new Text(
             $this->client(
                 $request->clientOptions(),
-                $request->clientRetry()
+                $request->clientRetry(),
+                $request
             ),
             $request
         );
@@ -46,7 +48,8 @@ readonly class Anthropic implements Provider
         $handler = new Structured(
             $this->client(
                 $request->clientOptions(),
-                $request->clientRetry()
+                $request->clientRetry(),
+                $request
             ),
             $request
         );
@@ -59,7 +62,8 @@ readonly class Anthropic implements Provider
     {
         $handler = new Stream($this->client(
             $request->clientOptions(),
-            $request->clientRetry()
+            $request->clientRetry(),
+            $request
         ));
 
         return $handler->handle($request);
@@ -75,12 +79,20 @@ readonly class Anthropic implements Provider
      * @param  array<string, mixed>  $options
      * @param  array<mixed>  $retry
      */
-    protected function client(array $options = [], array $retry = []): PendingRequest
+    protected function client(array $options = [], array $retry = [], ?PrismRequest $request = null): PendingRequest
     {
+        $betaFeatures = $this->betaFeatures;
+        
+        // Automatically add MCP Connector beta header if MCP servers are present
+        if (($request instanceof TextRequest || $request instanceof StructuredRequest) && ! empty($request->mcpServers())) {
+            $mcpBeta = 'mcp-client-2025-04-04';
+            $betaFeatures = $betaFeatures ? $betaFeatures . ',' . $mcpBeta : $mcpBeta;
+        }
+
         return Http::withHeaders(array_filter([
             'x-api-key' => $this->apiKey,
             'anthropic-version' => $this->apiVersion,
-            'anthropic-beta' => $this->betaFeatures,
+            'anthropic-beta' => $betaFeatures,
         ]))
             ->withOptions($options)
             ->retry(...$retry)

--- a/src/Providers/Anthropic/Anthropic.php
+++ b/src/Providers/Anthropic/Anthropic.php
@@ -84,7 +84,7 @@ readonly class Anthropic implements Provider
         $betaFeatures = $this->betaFeatures;
         
         // Automatically add MCP Connector beta header if MCP servers are present
-        if (($request instanceof TextRequest || $request instanceof StructuredRequest) && ! empty($request->mcpServers())) {
+        if (($request instanceof TextRequest || $request instanceof StructuredRequest) && $request->mcpServers() !== []) {
             $mcpBeta = 'mcp-client-2025-04-04';
             $betaFeatures = $betaFeatures ? $betaFeatures . ',' . $mcpBeta : $mcpBeta;
         }

--- a/src/Providers/Anthropic/Handlers/Stream.php
+++ b/src/Providers/Anthropic/Handlers/Stream.php
@@ -164,7 +164,7 @@ class Stream
             ->setTempContentBlockType($blockType)
             ->setTempContentBlockIndex($blockIndex);
 
-        if ($blockType === 'tool_use') {
+        if ($blockType === 'tool_use' || $blockType === 'mcp_tool_use') {
             $this->state->addToolCall($blockIndex, [
                 'id' => data_get($chunk, 'content_block.id'),
                 'name' => data_get($chunk, 'content_block.name'),
@@ -185,7 +185,7 @@ class Stream
             return $this->handleTextBlockDelta($chunk, $deltaType);
         }
 
-        if ($blockType === 'tool_use' && $deltaType === 'input_json_delta') {
+        if (($blockType === 'tool_use' || $blockType === 'mcp_tool_use') && $deltaType === 'input_json_delta') {
             return $this->handleToolInputDelta($chunk);
         }
 

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -96,7 +96,7 @@ class Structured extends AnthropicHandlerAbstract
         // Add MCP servers if present
         if (! empty($request->mcpServers())) {
             $payload['mcp_servers'] = array_map(
-                fn ($mcpServer) => $mcpServer->toArray(),
+                fn ($mcpServer): array => $mcpServer->toArray(),
                 $request->mcpServers()
             );
         }

--- a/src/Providers/Anthropic/Handlers/Structured.php
+++ b/src/Providers/Anthropic/Handlers/Structured.php
@@ -76,7 +76,7 @@ class Structured extends AnthropicHandlerAbstract
             throw new \InvalidArgumentException('Request must be an instance of '.StructuredRequest::class);
         }
 
-        return array_filter([
+        $payload = array_filter([
             'model' => $request->model(),
             'messages' => MessageMap::map($request->messages(), $request->providerOptions()),
             'system' => MessageMap::mapSystemMessages($request->systemPrompts()),
@@ -92,6 +92,16 @@ class Structured extends AnthropicHandlerAbstract
             'temperature' => $request->temperature(),
             'top_p' => $request->topP(),
         ]);
+
+        // Add MCP servers if present
+        if (! empty($request->mcpServers())) {
+            $payload['mcp_servers'] = array_map(
+                fn ($mcpServer) => $mcpServer->toArray(),
+                $request->mcpServers()
+            );
+        }
+
+        return $payload;
     }
 
     protected function prepareTempResponse(): void

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -197,7 +197,8 @@ class Text extends AnthropicHandlerAbstract
         $contents = data_get($data, 'content', []);
 
         foreach ($contents as $content) {
-            if (data_get($content, 'type') === 'tool_use') {
+            $contentType = data_get($content, 'type');
+            if ($contentType === 'tool_use' || $contentType === 'mcp_tool_use') {
                 $toolCalls[] = new ToolCall(
                     id: data_get($content, 'id'),
                     name: data_get($content, 'name'),

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -81,7 +81,7 @@ class Text extends AnthropicHandlerAbstract
             throw new \InvalidArgumentException('Request must be an instance of '.TextRequest::class);
         }
 
-        return array_filter([
+        $payload = array_filter([
             'model' => $request->model(),
             'system' => MessageMap::mapSystemMessages($request->systemPrompts()),
             'messages' => MessageMap::map($request->messages(), $request->providerOptions()),
@@ -99,6 +99,16 @@ class Text extends AnthropicHandlerAbstract
             'tools' => ToolMap::map($request->tools()),
             'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
         ]);
+
+        // Add MCP servers if present
+        if (! empty($request->mcpServers())) {
+            $payload['mcp_servers'] = array_map(
+                fn ($mcpServer) => $mcpServer->toArray(),
+                $request->mcpServers()
+            );
+        }
+
+        return $payload;
     }
 
     protected function handleToolCalls(): Response

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -103,7 +103,7 @@ class Text extends AnthropicHandlerAbstract
         // Add MCP servers if present
         if (! empty($request->mcpServers())) {
             $payload['mcp_servers'] = array_map(
-                fn ($mcpServer) => $mcpServer->toArray(),
+                fn ($mcpServer): array => $mcpServer->toArray(),
                 $request->mcpServers()
             );
         }

--- a/src/Providers/Anthropic/Maps/MessageMap.php
+++ b/src/Providers/Anthropic/Maps/MessageMap.php
@@ -85,7 +85,7 @@ class MessageMap
         return [
             'role' => 'user',
             'content' => array_map(fn (ToolResult $toolResult): array => [
-                'type' => 'tool_result',
+                'type' => str_starts_with($toolResult->toolCallId, 'mcptoolu_') ? 'mcp_tool_result' : 'tool_result',
                 'tool_use_id' => $toolResult->toolCallId,
                 'content' => $toolResult->result,
             ], $message->toolResults),

--- a/src/Structured/PendingRequest.php
+++ b/src/Structured/PendingRequest.php
@@ -8,6 +8,7 @@ use Prism\Prism\Concerns\ConfiguresClient;
 use Prism\Prism\Concerns\ConfiguresModels;
 use Prism\Prism\Concerns\ConfiguresProviders;
 use Prism\Prism\Concerns\ConfiguresStructuredOutput;
+use Prism\Prism\Concerns\HasMCPServers;
 use Prism\Prism\Concerns\HasMessages;
 use Prism\Prism\Concerns\HasPrompts;
 use Prism\Prism\Concerns\HasProviderOptions;
@@ -21,6 +22,7 @@ class PendingRequest
     use ConfiguresModels;
     use ConfiguresProviders;
     use ConfiguresStructuredOutput;
+    use HasMCPServers;
     use HasMessages;
     use HasPrompts;
     use HasProviderOptions;
@@ -56,18 +58,19 @@ class PendingRequest
         }
 
         return new Request(
-            model: $this->model,
             systemPrompts: $this->systemPrompts,
+            model: $this->model,
             prompt: $this->prompt,
             messages: $messages,
-            temperature: $this->temperature,
             maxTokens: $this->maxTokens,
+            temperature: $this->temperature,
             topP: $this->topP,
+            mcpServers: $this->mcpServers,
             clientOptions: $this->clientOptions,
             clientRetry: $this->clientRetry,
-            providerOptions: $this->providerOptions,
             schema: $this->schema,
             mode: $this->structuredMode,
+            providerOptions: $this->providerOptions,
         );
     }
 }

--- a/src/Structured/Request.php
+++ b/src/Structured/Request.php
@@ -11,6 +11,7 @@ use Prism\Prism\Contracts\Message;
 use Prism\Prism\Contracts\PrismRequest;
 use Prism\Prism\Contracts\Schema;
 use Prism\Prism\Enums\StructuredMode;
+use Prism\Prism\ValueObjects\MCPServer;
 use Prism\Prism\ValueObjects\Messages\SystemMessage;
 
 class Request implements PrismRequest
@@ -20,6 +21,7 @@ class Request implements PrismRequest
     /**
      * @param  SystemMessage[]  $systemPrompts
      * @param  array<int, Message>  $messages
+     * @param  array<int, MCPServer>  $mcpServers
      * @param  array<string, mixed>  $clientOptions
      * @param  array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $clientRetry
      * @param  array<string, mixed>  $providerOptions
@@ -32,6 +34,7 @@ class Request implements PrismRequest
         protected ?int $maxTokens,
         protected int|float|null $temperature,
         protected int|float|null $topP,
+        protected array $mcpServers,
         protected array $clientOptions,
         protected array $clientRetry,
         protected Schema $schema,
@@ -66,6 +69,14 @@ class Request implements PrismRequest
     public function messages(): array
     {
         return $this->messages;
+    }
+
+    /**
+     * @return MCPServer[]
+     */
+    public function mcpServers(): array
+    {
+        return $this->mcpServers;
     }
 
     public function maxTokens(): ?int

--- a/src/Text/PendingRequest.php
+++ b/src/Text/PendingRequest.php
@@ -10,6 +10,7 @@ use Prism\Prism\Concerns\ConfiguresGeneration;
 use Prism\Prism\Concerns\ConfiguresModels;
 use Prism\Prism\Concerns\ConfiguresProviders;
 use Prism\Prism\Concerns\ConfiguresTools;
+use Prism\Prism\Concerns\HasMCPServers;
 use Prism\Prism\Concerns\HasMessages;
 use Prism\Prism\Concerns\HasPrompts;
 use Prism\Prism\Concerns\HasProviderOptions;
@@ -24,6 +25,7 @@ class PendingRequest
     use ConfiguresModels;
     use ConfiguresProviders;
     use ConfiguresTools;
+    use HasMCPServers;
     use HasMessages;
     use HasPrompts;
     use HasProviderOptions;
@@ -67,11 +69,12 @@ class PendingRequest
             systemPrompts: $this->systemPrompts,
             prompt: $this->prompt,
             messages: $messages,
-            temperature: $this->temperature,
-            maxTokens: $this->maxTokens,
             maxSteps: $this->maxSteps,
+            maxTokens: $this->maxTokens,
+            temperature: $this->temperature,
             topP: $this->topP,
             tools: $this->tools,
+            mcpServers: $this->mcpServers,
             clientOptions: $this->clientOptions,
             clientRetry: $this->clientRetry,
             toolChoice: $this->toolChoice,

--- a/src/Text/Request.php
+++ b/src/Text/Request.php
@@ -11,6 +11,7 @@ use Prism\Prism\Contracts\Message;
 use Prism\Prism\Contracts\PrismRequest;
 use Prism\Prism\Enums\ToolChoice;
 use Prism\Prism\Tool;
+use Prism\Prism\ValueObjects\MCPServer;
 use Prism\Prism\ValueObjects\Messages\SystemMessage;
 
 class Request implements PrismRequest
@@ -21,6 +22,7 @@ class Request implements PrismRequest
      * @param  SystemMessage[]  $systemPrompts
      * @param  array<int, Message>  $messages
      * @param  array<int, Tool>  $tools
+     * @param  array<int, MCPServer>  $mcpServers
      * @param  array<string, mixed>  $clientOptions
      * @param  array{0: array<int, int>|int, 1?: Closure|int, 2?: ?callable, 3?: bool}  $clientRetry
      * @param  array<string, mixed>  $providerOptions
@@ -35,6 +37,7 @@ class Request implements PrismRequest
         protected int|float|null $temperature,
         protected int|float|null $topP,
         protected array $tools,
+        protected array $mcpServers,
         protected array $clientOptions,
         protected array $clientRetry,
         protected string|ToolChoice|null $toolChoice,
@@ -70,6 +73,14 @@ class Request implements PrismRequest
     public function tools(): array
     {
         return $this->tools;
+    }
+
+    /**
+     * @return MCPServer[]
+     */
+    public function mcpServers(): array
+    {
+        return $this->mcpServers;
     }
 
     public function topP(): int|float|null

--- a/src/ValueObjects/MCPServer.php
+++ b/src/ValueObjects/MCPServer.php
@@ -25,7 +25,7 @@ class MCPServer
             $config['authorization_token'] = $this->authorizationToken;
         }
 
-        if (! empty($this->toolConfiguration)) {
+        if ($this->toolConfiguration !== []) {
             $config['tool_configuration'] = $this->toolConfiguration;
         }
 

--- a/src/ValueObjects/MCPServer.php
+++ b/src/ValueObjects/MCPServer.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Prism\ValueObjects;
+
+class MCPServer
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $url,
+        public readonly ?string $authorizationToken = null,
+        public readonly array $toolConfiguration = [],
+    ) {}
+
+    public function toArray(): array
+    {
+        $config = [
+            'type' => 'url',
+            'url' => $this->url,
+            'name' => $this->name,
+        ];
+
+        if ($this->authorizationToken !== null) {
+            $config['authorization_token'] = $this->authorizationToken;
+        }
+
+        if (! empty($this->toolConfiguration)) {
+            $config['tool_configuration'] = $this->toolConfiguration;
+        }
+
+        return $config;
+    }
+}

--- a/tests/Concerns/HasMCPServersTest.php
+++ b/tests/Concerns/HasMCPServersTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Concerns\HasMCPServers;
+use Prism\Prism\ValueObjects\MCPServer;
+
+// Create a test class that uses the trait
+class TestClassWithMCPServers
+{
+    use HasMCPServers;
+}
+
+beforeEach(function (): void {
+    $this->testClass = new TestClassWithMCPServers;
+});
+
+it('starts with empty MCP servers', function (): void {
+    expect($this->testClass->getMCPServers())->toBe([]);
+    expect($this->testClass->hasMCPServers())->toBeFalse();
+});
+
+it('can add a single MCP server with withMCPServer', function (): void {
+    $result = $this->testClass->withMCPServer(
+        name: 'test-server',
+        url: 'https://test.com',
+        authorizationToken: 'token',
+        toolConfiguration: ['config' => 'value']
+    );
+
+    expect($result)->toBe($this->testClass); // Returns self for chaining
+    expect($this->testClass->hasMCPServers())->toBeTrue();
+
+    $servers = $this->testClass->getMCPServers();
+    expect($servers)->toHaveCount(1);
+    expect($servers[0])->toBeInstanceOf(MCPServer::class);
+    expect($servers[0]->name)->toBe('test-server');
+    expect($servers[0]->url)->toBe('https://test.com');
+    expect($servers[0]->authorizationToken)->toBe('token');
+    expect($servers[0]->toolConfiguration)->toBe(['config' => 'value']);
+});
+
+it('can add MCP server with minimal parameters', function (): void {
+    $this->testClass->withMCPServer('minimal', 'https://minimal.com');
+
+    $servers = $this->testClass->getMCPServers();
+    expect($servers)->toHaveCount(1);
+    expect($servers[0]->name)->toBe('minimal');
+    expect($servers[0]->url)->toBe('https://minimal.com');
+    expect($servers[0]->authorizationToken)->toBeNull();
+    expect($servers[0]->toolConfiguration)->toBe([]);
+});
+
+it('can chain multiple withMCPServer calls', function (): void {
+    $result = $this->testClass
+        ->withMCPServer('server1', 'https://server1.com')
+        ->withMCPServer('server2', 'https://server2.com', 'token2');
+
+    expect($result)->toBe($this->testClass);
+    expect($this->testClass->getMCPServers())->toHaveCount(2);
+    expect($this->testClass->getMCPServers()[0]->name)->toBe('server1');
+    expect($this->testClass->getMCPServers()[1]->name)->toBe('server2');
+});
+
+it('can add multiple servers with withMCPServers using MCPServer objects', function (): void {
+    $server1 = new MCPServer('obj1', 'https://obj1.com');
+    $server2 = new MCPServer('obj2', 'https://obj2.com', 'token');
+
+    $result = $this->testClass->withMCPServers([$server1, $server2]);
+
+    expect($result)->toBe($this->testClass);
+    expect($this->testClass->getMCPServers())->toHaveCount(2);
+    expect($this->testClass->getMCPServers()[0])->toBe($server1);
+    expect($this->testClass->getMCPServers()[1])->toBe($server2);
+});
+
+it('can add multiple servers with withMCPServers using arrays', function (): void {
+    $servers = [
+        [
+            'name' => 'array1',
+            'url' => 'https://array1.com',
+            'authorization_token' => 'token1',
+            'tool_configuration' => ['setting' => 'value1'],
+        ],
+        [
+            'name' => 'array2',
+            'url' => 'https://array2.com',
+        ],
+    ];
+
+    $result = $this->testClass->withMCPServers($servers);
+
+    expect($result)->toBe($this->testClass);
+    expect($this->testClass->getMCPServers())->toHaveCount(2);
+
+    $mcpServers = $this->testClass->getMCPServers();
+    expect($mcpServers[0]->name)->toBe('array1');
+    expect($mcpServers[0]->authorizationToken)->toBe('token1');
+    expect($mcpServers[0]->toolConfiguration)->toBe(['setting' => 'value1']);
+
+    expect($mcpServers[1]->name)->toBe('array2');
+    expect($mcpServers[1]->authorizationToken)->toBeNull();
+});
+
+it('can mix MCPServer objects and arrays in withMCPServers', function (): void {
+    $serverObj = new MCPServer('object', 'https://object.com');
+    $serverArray = [
+        'name' => 'array',
+        'url' => 'https://array.com',
+        'authorization_token' => 'array-token',
+    ];
+
+    $this->testClass->withMCPServers([$serverObj, $serverArray]);
+
+    $servers = $this->testClass->getMCPServers();
+    expect($servers)->toHaveCount(2);
+    expect($servers[0])->toBe($serverObj);
+    expect($servers[1]->name)->toBe('array');
+    expect($servers[1]->authorizationToken)->toBe('array-token');
+});
+
+it('accumulates servers across multiple calls', function (): void {
+    $this->testClass
+        ->withMCPServer('single', 'https://single.com')
+        ->withMCPServers([
+            ['name' => 'batch1', 'url' => 'https://batch1.com'],
+            ['name' => 'batch2', 'url' => 'https://batch2.com'],
+        ])
+        ->withMCPServer('another', 'https://another.com');
+
+    expect($this->testClass->getMCPServers())->toHaveCount(4);
+    expect($this->testClass->getMCPServers()[0]->name)->toBe('single');
+    expect($this->testClass->getMCPServers()[1]->name)->toBe('batch1');
+    expect($this->testClass->getMCPServers()[2]->name)->toBe('batch2');
+    expect($this->testClass->getMCPServers()[3]->name)->toBe('another');
+});

--- a/tests/Providers/Anthropic/MCPConnectorTest.php
+++ b/tests/Providers/Anthropic/MCPConnectorTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Enums\StructuredMode;
+use Prism\Prism\Providers\Anthropic\Handlers\Structured;
+use Prism\Prism\Providers\Anthropic\Handlers\Text;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\ValueObjects\MCPServer;
+
+beforeEach(function (): void {
+    config()->set('prism.providers.anthropic.api_key', 'sk-test-key');
+});
+
+it('includes MCP servers in text request payload', function (): void {
+    $mcpServer1 = new MCPServer('filesystem', 'https://fs-server.com', 'fs-token', ['readonly' => true]);
+    $mcpServer2 = new MCPServer('database', 'https://db-server.com');
+
+    $request = new TextRequest(
+        model: 'claude-3-sonnet',
+        systemPrompts: [],
+        prompt: 'Test prompt',
+        messages: [],
+        maxSteps: 5,
+        maxTokens: 1000,
+        temperature: 0.7,
+        topP: 0.9,
+        tools: [],
+        mcpServers: [$mcpServer1, $mcpServer2],
+        clientOptions: [],
+        clientRetry: [],
+        toolChoice: null,
+        providerOptions: []
+    );
+
+    $payload = Text::buildHttpRequestPayload($request);
+
+    expect($payload)->toHaveKey('mcp_servers');
+    expect($payload['mcp_servers'])->toHaveCount(2);
+
+    expect($payload['mcp_servers'][0])->toBe([
+        'type' => 'url',
+        'url' => 'https://fs-server.com',
+        'name' => 'filesystem',
+        'authorization_token' => 'fs-token',
+        'tool_configuration' => ['readonly' => true],
+    ]);
+
+    expect($payload['mcp_servers'][1])->toBe([
+        'type' => 'url',
+        'url' => 'https://db-server.com',
+        'name' => 'database',
+    ]);
+});
+
+it('includes MCP servers in structured request payload', function (): void {
+    $mcpServer = new MCPServer('analytics', 'https://analytics.com', 'analytics-token');
+    $schema = new ObjectSchema(
+        'result',
+        'The result object',
+        [new StringSchema('data', 'The result data')]
+    );
+
+    $request = new StructuredRequest(
+        systemPrompts: [],
+        model: 'claude-3-sonnet',
+        prompt: 'Analyze data',
+        messages: [],
+        maxTokens: 1000,
+        temperature: 0.5,
+        topP: 0.8,
+        mcpServers: [$mcpServer],
+        clientOptions: [],
+        clientRetry: [],
+        schema: $schema,
+        mode: StructuredMode::Auto,
+        providerOptions: []
+    );
+
+    $payload = Structured::buildHttpRequestPayload($request);
+
+    expect($payload)->toHaveKey('mcp_servers');
+    expect($payload['mcp_servers'])->toHaveCount(1);
+    expect($payload['mcp_servers'][0])->toBe([
+        'type' => 'url',
+        'url' => 'https://analytics.com',
+        'name' => 'analytics',
+        'authorization_token' => 'analytics-token',
+    ]);
+});
+
+it('does not include mcp_servers in payload when no servers are configured', function (): void {
+    $request = new TextRequest(
+        model: 'claude-3-sonnet',
+        systemPrompts: [],
+        prompt: 'Test without MCP',
+        messages: [],
+        maxSteps: 5,
+        maxTokens: 1000,
+        temperature: 0.7,
+        topP: 0.9,
+        tools: [],
+        mcpServers: [], // Empty array
+        clientOptions: [],
+        clientRetry: [],
+        toolChoice: null,
+        providerOptions: []
+    );
+
+    $payload = Text::buildHttpRequestPayload($request);
+
+    expect($payload)->not->toHaveKey('mcp_servers');
+});
+
+it('excludes mcp_servers from structured payload when empty', function (): void {
+    $schema = new ObjectSchema(
+        'result',
+        'The result object',
+        [new StringSchema('data', 'The result data')]
+    );
+
+    $request = new StructuredRequest(
+        systemPrompts: [],
+        model: 'claude-3-sonnet',
+        prompt: 'Test without MCP',
+        messages: [],
+        maxTokens: 1000,
+        temperature: 0.5,
+        topP: 0.8,
+        mcpServers: [], // Empty array
+        clientOptions: [],
+        clientRetry: [],
+        schema: $schema,
+        mode: StructuredMode::Auto,
+        providerOptions: []
+    );
+
+    $payload = Structured::buildHttpRequestPayload($request);
+
+    expect($payload)->not->toHaveKey('mcp_servers');
+});

--- a/tests/Structured/MCPRequestTest.php
+++ b/tests/Structured/MCPRequestTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Enums\StructuredMode;
+use Prism\Prism\Schema\ObjectSchema;
+use Prism\Prism\Schema\StringSchema;
+use Prism\Prism\Structured\Request as StructuredRequest;
+use Prism\Prism\ValueObjects\MCPServer;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+
+it('includes MCP servers in structured request', function (): void {
+    $mcpServer = new MCPServer('analytics-server', 'https://analytics.com', 'analytics-token');
+    $schema = new ObjectSchema(
+        'result',
+        'The result object',
+        [new StringSchema('data', 'The result data')]
+    );
+
+    $request = new StructuredRequest(
+        systemPrompts: [],
+        model: 'claude-3-sonnet',
+        prompt: 'Analyze data',
+        messages: [new UserMessage('Analyze this data')],
+        maxTokens: 1000,
+        temperature: 0.5,
+        topP: 0.8,
+        mcpServers: [$mcpServer],
+        clientOptions: [],
+        clientRetry: [],
+        schema: $schema,
+        mode: StructuredMode::Auto,
+        providerOptions: []
+    );
+
+    expect($request->mcpServers())->toHaveCount(1);
+    expect($request->mcpServers()[0])->toBe($mcpServer);
+    expect($request->mcpServers()[0]->name)->toBe('analytics-server');
+    expect($request->mcpServers()[0]->authorizationToken)->toBe('analytics-token');
+});
+
+it('handles empty MCP servers in structured request', function (): void {
+    $schema = new ObjectSchema(
+        'data',
+        'The data object',
+        [new StringSchema('items', 'The data items')]
+    );
+
+    $request = new StructuredRequest(
+        systemPrompts: [],
+        model: 'claude-3-sonnet',
+        prompt: 'Process data',
+        messages: [],
+        maxTokens: 500,
+        temperature: null,
+        topP: null,
+        mcpServers: [],
+        clientOptions: [],
+        clientRetry: [],
+        schema: $schema,
+        mode: StructuredMode::Auto,
+        providerOptions: []
+    );
+
+    expect($request->mcpServers())->toBe([]);
+});
+
+it('preserves multiple MCP servers in structured request', function (): void {
+    $server1 = new MCPServer('database', 'https://db.com', 'db-token');
+    $server2 = new MCPServer('filesystem', 'https://fs.com');
+    $server3 = new MCPServer('api', 'https://api.com', 'api-token', ['readonly' => true]);
+
+    $schema = new ObjectSchema(
+        'summary',
+        'The summary object',
+        [new StringSchema('text', 'The summary text')]
+    );
+
+    $request = new StructuredRequest(
+        systemPrompts: [],
+        model: 'claude-3-sonnet',
+        prompt: 'Create summary',
+        messages: [],
+        maxTokens: 2000,
+        temperature: 0.3,
+        topP: 0.9,
+        mcpServers: [$server1, $server2, $server3],
+        clientOptions: [],
+        clientRetry: [],
+        schema: $schema,
+        mode: StructuredMode::Auto,
+        providerOptions: []
+    );
+
+    $mcpServers = $request->mcpServers();
+    expect($mcpServers)->toHaveCount(3);
+    expect($mcpServers[0])->toBe($server1);
+    expect($mcpServers[1])->toBe($server2);
+    expect($mcpServers[2])->toBe($server3);
+    expect($mcpServers[2]->toolConfiguration)->toBe(['readonly' => true]);
+});

--- a/tests/Text/MCPRequestTest.php
+++ b/tests/Text/MCPRequestTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\ValueObjects\MCPServer;
+use Prism\Prism\ValueObjects\Messages\UserMessage;
+
+it('includes MCP servers in text request', function (): void {
+    $mcpServer = new MCPServer('test-server', 'https://test.com', 'token');
+
+    $request = new TextRequest(
+        model: 'claude-3-sonnet',
+        systemPrompts: [],
+        prompt: 'Test prompt',
+        messages: [new UserMessage('Test message')],
+        maxSteps: 5,
+        maxTokens: 1000,
+        temperature: 0.7,
+        topP: 0.9,
+        tools: [],
+        mcpServers: [$mcpServer],
+        clientOptions: [],
+        clientRetry: [],
+        toolChoice: null,
+        providerOptions: []
+    );
+
+    expect($request->mcpServers())->toHaveCount(1);
+    expect($request->mcpServers()[0])->toBe($mcpServer);
+    expect($request->mcpServers()[0]->name)->toBe('test-server');
+});
+
+it('handles empty MCP servers array', function (): void {
+    $request = new TextRequest(
+        model: 'claude-3-sonnet',
+        systemPrompts: [],
+        prompt: 'Test prompt',
+        messages: [],
+        maxSteps: 5,
+        maxTokens: 1000,
+        temperature: 0.7,
+        topP: 0.9,
+        tools: [],
+        mcpServers: [],
+        clientOptions: [],
+        clientRetry: [],
+        toolChoice: null,
+        providerOptions: []
+    );
+
+    expect($request->mcpServers())->toBe([]);
+});
+
+it('preserves multiple MCP servers in correct order', function (): void {
+    $server1 = new MCPServer('server1', 'https://server1.com');
+    $server2 = new MCPServer('server2', 'https://server2.com', 'token2');
+    $server3 = new MCPServer('server3', 'https://server3.com');
+
+    $request = new TextRequest(
+        model: 'claude-3-sonnet',
+        systemPrompts: [],
+        prompt: null,
+        messages: [],
+        maxSteps: 5,
+        maxTokens: null,
+        temperature: null,
+        topP: null,
+        tools: [],
+        mcpServers: [$server1, $server2, $server3],
+        clientOptions: [],
+        clientRetry: [],
+        toolChoice: null,
+        providerOptions: []
+    );
+
+    $mcpServers = $request->mcpServers();
+    expect($mcpServers)->toHaveCount(3);
+    expect($mcpServers[0])->toBe($server1);
+    expect($mcpServers[1])->toBe($server2);
+    expect($mcpServers[2])->toBe($server3);
+});

--- a/tests/ValueObjects/MCPServerTest.php
+++ b/tests/ValueObjects/MCPServerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use Prism\Prism\ValueObjects\MCPServer;
+
+it('can create an MCPServer with all parameters', function (): void {
+    $mcpServer = new MCPServer(
+        name: 'test-server',
+        url: 'https://test-server.com',
+        authorizationToken: 'test-token',
+        toolConfiguration: ['setting' => 'value']
+    );
+
+    expect($mcpServer->name)->toBe('test-server');
+    expect($mcpServer->url)->toBe('https://test-server.com');
+    expect($mcpServer->authorizationToken)->toBe('test-token');
+    expect($mcpServer->toolConfiguration)->toBe(['setting' => 'value']);
+});
+
+it('can create an MCPServer with minimal parameters', function (): void {
+    $mcpServer = new MCPServer(
+        name: 'minimal-server',
+        url: 'https://minimal.com'
+    );
+
+    expect($mcpServer->name)->toBe('minimal-server');
+    expect($mcpServer->url)->toBe('https://minimal.com');
+    expect($mcpServer->authorizationToken)->toBeNull();
+    expect($mcpServer->toolConfiguration)->toBe([]);
+});
+
+it('converts to array format correctly with all fields', function (): void {
+    $mcpServer = new MCPServer(
+        name: 'full-server',
+        url: 'https://full-server.com',
+        authorizationToken: 'full-token',
+        toolConfiguration: ['config' => 'test']
+    );
+
+    $array = $mcpServer->toArray();
+
+    expect($array)->toBe([
+        'type' => 'url',
+        'url' => 'https://full-server.com',
+        'name' => 'full-server',
+        'authorization_token' => 'full-token',
+        'tool_configuration' => ['config' => 'test'],
+    ]);
+});
+
+it('converts to array format correctly with minimal fields', function (): void {
+    $mcpServer = new MCPServer(
+        name: 'minimal-server',
+        url: 'https://minimal.com'
+    );
+
+    $array = $mcpServer->toArray();
+
+    expect($array)->toBe([
+        'type' => 'url',
+        'url' => 'https://minimal.com',
+        'name' => 'minimal-server',
+    ]);
+});
+
+it('excludes null authorization token from array', function (): void {
+    $mcpServer = new MCPServer(
+        name: 'no-auth',
+        url: 'https://no-auth.com',
+        authorizationToken: null
+    );
+
+    $array = $mcpServer->toArray();
+
+    expect($array)->not->toHaveKey('authorization_token');
+});
+
+it('excludes empty tool configuration from array', function (): void {
+    $mcpServer = new MCPServer(
+        name: 'no-config',
+        url: 'https://no-config.com',
+        toolConfiguration: []
+    );
+
+    $array = $mcpServer->toArray();
+
+    expect($array)->not->toHaveKey('tool_configuration');
+});


### PR DESCRIPTION
## Summary
• Add support for MCP response content types (mcp_tool_use and mcp_tool_result) in Anthropic provider handlers
• Complete MCP Connector implementation by enabling proper parsing of MCP tool responses from Anthropic's API

## Test plan
- [x] Run existing MCP Connector tests to ensure no regressions
- [x] Verify all Anthropic provider tests pass
- [x] Confirm MCP tool responses are properly handled in Text, Stream, and MessageMap handlers

🤖 Generated with [Claude Code](https://claude.ai/code)